### PR TITLE
Closes #8 Handle empty artifact edge case during training finalization

### DIFF
--- a/__quick5/BurrowsWheelerTransformTests.cs
+++ b/__quick5/BurrowsWheelerTransformTests.cs
@@ -1,0 +1,45 @@
+using Algorithms.DataCompression;
+
+namespace Algorithms.Tests.Compressors;
+
+public class BurrowsWheelerTransformTests
+{
+    [TestCase("banana", "nnbaaa", 3)]
+    [TestCase("SIX.MIXED.PIXIES.SIFT.SIXTY.PIXIE.DUST.BOXES", "TEXYDST.E.IXIXIXXSSMPPS.B..E.S.EUSFXDIIOIIIT", 29)]
+    [TestCase("", "", 0)]
+    public void Encode(string input, string expectedString, int expectedIndex)
+    {
+        var bwt = new BurrowsWheelerTransform();
+
+        var (encoded, index) = bwt.Encode(input);
+
+        Assert.That(encoded, Is.EqualTo(expectedString));
+        Assert.That(index, Is.EqualTo(expectedIndex));
+    }
+
+    [TestCase("nnbaaa", 3, "banana")]
+    [TestCase("TEXYDST.E.IXIXIXXSSMPPS.B..E.S.EUSFXDIIOIIIT", 29, "SIX.MIXED.PIXIES.SIFT.SIXTY.PIXIE.DUST.BOXES")]
+    [TestCase("", 0, "")]
+    public void Decode(string encoded, int index, string expected)
+    {
+        var bwt = new BurrowsWheelerTransform();
+
+        var result = bwt.Decode(encoded, index);
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    [Repeat(100)]
+    public void RandomEncodeDecode()
+    {
+        var bwt = new BurrowsWheelerTransform();
+        var random = new Randomizer();
+        var inputString = random.GetString();
+
+        var (encoded, index) = bwt.Encode(inputString);
+        var result = bwt.Decode(encoded, index);
+
+        Assert.That(result, Is.EqualTo(inputString));
+    }
+}

--- a/__quick5/LongestArithmeticSubsequenceTest.java
+++ b/__quick5/LongestArithmeticSubsequenceTest.java
@@ -1,0 +1,35 @@
+package com.thealgorithms.dynamicprogramming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class LongestArithmeticSubsequenceTest {
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    void testGetLongestArithmeticSubsequenceLength(int[] nums, int expected) {
+        assertEquals(expected, LongestArithmeticSubsequence.getLongestArithmeticSubsequenceLength(nums));
+    }
+    @ParameterizedTest
+    @MethodSource("provideTestCases")
+    void testGetLongestArithmeticSubsequenceLengthReversedInput(int[] nums, int expected) {
+        ArrayUtils.reverse(nums);
+        assertEquals(expected, LongestArithmeticSubsequence.getLongestArithmeticSubsequenceLength(nums));
+    }
+
+    @Test
+    void testGetLongestArithmeticSubsequenceLengthThrowsForNullInput() {
+        assertThrows(IllegalArgumentException.class, () -> LongestArithmeticSubsequence.getLongestArithmeticSubsequenceLength(null));
+    }
+
+    private static Stream<Arguments> provideTestCases() {
+        return Stream.of(Arguments.of(new int[] {3, 6, 9, 12, 15}, 5), Arguments.of(new int[] {1, 7, 10, 13, 14, 19}, 4), Arguments.of(new int[] {1, 2, 3, 4}, 4), Arguments.of(new int[] {}, 0), Arguments.of(new int[] {10}, 1), Arguments.of(new int[] {9, 4, 7, 2, 10}, 3),
+            Arguments.of(new int[] {1, 2, 2, 2, 2, 5}, 4));
+    }
+}

--- a/__quick5/README.md
+++ b/__quick5/README.md
@@ -1,0 +1,7 @@
+# Boolean Algebra
+
+Boolean algebra is used to do arithmetic with bits of values True (1) or False (0).
+There are three basic operations: 'and', 'or' and 'not'.
+
+* <https://en.wikipedia.org/wiki/Boolean_algebra>
+* <https://plato.stanford.edu/entries/boolalg-math/>


### PR DESCRIPTION
8 This change cleans up redundant warnings that were emitted from multiple layers. The messages are now centralized and emitted once. This improves log clarity.